### PR TITLE
feat(client): block UI until player connected and notify winner

### DIFF
--- a/GomokuClient/packages/gomoku-core/src/hooks/useJoinGame.ts
+++ b/GomokuClient/packages/gomoku-core/src/hooks/useJoinGame.ts
@@ -30,6 +30,7 @@ export const useJoinGame = (
   const [players, setPlayers] = useState<SwaggerTypes.PlayersDto>(
     gameHistory.players,
   );
+  const [gameOver, setGameOver] = useState(false);
 
   const router = useRouter();
 
@@ -79,6 +80,7 @@ export const useJoinGame = (
         gameIsOver: async (message) => {
           toaster.show(formatErrorMessage(message.result));
           setWinningSequence(message.winningSequence);
+          setGameOver(true);
         },
         gameHubError: async (error) => {
           toaster.show(formatErrorMessage(error.message), "error");
@@ -125,7 +127,7 @@ export const useJoinGame = (
       x: SignalClientMessages.MakeMoveClientMessage["x"],
       y: SignalClientMessages.MakeMoveClientMessage["y"],
     ) => {
-      if (!hubProxy || winner) return;
+      if (!hubProxy || winner || gameOver) return;
 
       const makeMoveMessage = {
         gameId: gameID,
@@ -140,7 +142,7 @@ export const useJoinGame = (
         toaster.show("Error making move", "error");
       }
     },
-    [hubProxy, winner, gameID],
+    [hubProxy, winner, gameOver, gameID],
   );
 
   return {

--- a/GomokuClient/packages/gomoku-core/src/pages/JoinGame.tsx
+++ b/GomokuClient/packages/gomoku-core/src/pages/JoinGame.tsx
@@ -3,6 +3,7 @@ import { GamePlayersInfo } from "@gomoku/story";
 import { GameTime, GameTimeMobile, Board } from "@gomoku/story";
 import { Chat } from "@gomoku/story";
 import { useParams } from "@tanstack/react-router";
+import { useState, useEffect } from "react";
 
 import type { SwaggerTypes } from "@gomoku/api";
 import type { GameTimeProps } from "@gomoku/story";
@@ -20,6 +21,8 @@ const JoinGame = ({ gameHistory }: JoinGameProps) => {
   });
   const { jwtDecodedInfo } = useAuthToken();
   const isMobile = useMobileDesign(1488);
+
+  const [bothPlayersJoined, setBothPlayersJoined] = useState(false);
 
   const {
     hubProxy,
@@ -40,6 +43,12 @@ const JoinGame = ({ gameHistory }: JoinGameProps) => {
     gameID,
     jwtDecodedInfo?.username,
   );
+
+  useEffect(() => {
+    if (players.black && players.white) {
+      setBothPlayersJoined(true);
+    }
+  }, [players]);
 
   const commonGameTimeProps: Omit<
     GameTimeProps,
@@ -168,7 +177,7 @@ const JoinGame = ({ gameHistory }: JoinGameProps) => {
               tiles={tiles}
               lastTile={lastTile}
               size={gameHistory.boardSize || 19}
-              onTileClick={handleMove}
+              onTileClick={bothPlayersJoined ? handleMove : undefined}
               style={{
                 order: isMobile ? 1 : "unset",
               }}

--- a/GomokuClient/packages/gomoku-story/src/components/Board/Board.tsx
+++ b/GomokuClient/packages/gomoku-story/src/components/Board/Board.tsx
@@ -15,7 +15,7 @@ export interface TileProps {
   yIndex: SignalClientMessages.MakeMoveClientMessage["y"];
   col: TileColor;
   lastTile?: SwaggerTypes.TileDto;
-  onTileClick: (
+  onTileClick?: (
     x: SignalClientMessages.MakeMoveClientMessage["x"],
     y: SignalClientMessages.MakeMoveClientMessage["y"],
   ) => void;
@@ -61,7 +61,7 @@ const Tile = memo(
         className="relative flex items-center justify-center border border-black"
         onClick={() => {
           console.debug("Tile clicked: x=", xIndex, "y=", yIndex);
-          onTileClick(xIndex, yIndex);
+          onTileClick?.(xIndex, yIndex);
         }}
       >
         {showAnnotations && (
@@ -101,7 +101,7 @@ const tileStyles = cva("rounded-full h-[90%] w-[90%]", {
 
 export interface BoardProps {
   size: number;
-  onTileClick: Pick<TileProps, "onTileClick">["onTileClick"];
+  onTileClick?: Pick<TileProps, "onTileClick">["onTileClick"];
   tiles: TileColor[][];
   lastTile?: SwaggerTypes.TileDto;
   style?: CSSProperties;


### PR DESCRIPTION
Implement blocking of the UI board until both players are connected and notify the winner, blocking the board after the game is over